### PR TITLE
fix(householdsList): fix getDerivedStateFromProps for dwelling

### DIFF
--- a/src/components/HouseholdsList/index.js
+++ b/src/components/HouseholdsList/index.js
@@ -95,8 +95,8 @@ class HouseholdsList extends Component {
         this.props.requestDwelling(id, dwellingOrder);
     }
 
-    static getDerivedStateFromProps(nextProps, state) {
-        if (nextProps.dwelling && !state.dwelling) {
+    static getDerivedStateFromProps(nextProps) {
+        if (nextProps.dwelling) {
             return {
                 dwelling: new Dwelling(nextProps.dwelling)
             };


### PR DESCRIPTION
the component has the same state with different dwelling so i check that dwellings are different.

Other solution is add key to component but i dont't like this.